### PR TITLE
Optimize Include for MergeOption.NoTracking

### DIFF
--- a/WAQS.Client/ttincludes/WAQS.Client.Fx.ClientContext.ttinclude
+++ b/WAQS.Client/ttincludes/WAQS.Client.Fx.ClientContext.ttinclude
@@ -1975,14 +1975,23 @@ public static class AsyncQueryableExtensions
         where ManyT : IEntity
     {
         var many = ((IEnumerable<object>)manyValues[0]).Cast<ManyT>();
-        if (mergeOption == MergeOption.NoTracking)
-        {
-            var ones = ((IEnumerable<object>)oneValues).Cast<OneT>();
-            foreach (var one in ones)
-                foreach (var manyEntity in many.Where(m => fkTest(one, m)))
-                    getTrackableCollection(one).Attach(manyEntity);
-        }
-        return many;
+		if (mergeOption == MergeOption.NoTracking)
+		{
+			var manyList = many.ToArray();
+			var ones = ((IEnumerable<object>)oneValues).Cast<OneT>().ToArray();
+			foreach (var one in ones)
+			{
+				for (int i = 0; i < manyList.Length; i++)
+				{
+					if (fkTest(one, manyList[i]))
+					{
+						getTrackableCollection(one).Attach(manyList[i]);
+					}
+				}
+			}
+		}
+
+		return many;
     }
         
     public static IAsyncQueryableValue<OneT> IncludeOneOneToMany<OneT, ManyT>(IAsyncQueryableValue<OneT> source, Expression<Func<OneT, IEnumerable<ManyT>>> exp, Expression<Func<IEnumerable<ManyT>, IEnumerable<ManyT>>> queryTransform, Func<OneT, IEntityCollection<ManyT>> getTrackableCollection, bool manyToMany = false)
@@ -2054,8 +2063,14 @@ public static class AsyncQueryableExtensions
             return null;
         var many = ((IEnumerable<object>)manyValues[0]).Cast<ManyT>();
         if (mergeOption == MergeOption.NoTracking || manyToMany)
-            foreach (var manyElt in many)
-                getTrackableCollection(one).Attach(manyElt);
+        {
+			var manyList = many.ToArray();
+			foreach (var manyElt in manyList)
+			{
+				getTrackableCollection(one).Attach(manyElt);
+			}
+		}
+
         return many;
     }
         
@@ -2109,16 +2124,25 @@ public static class AsyncQueryableExtensions
         where OneT : IEntity
         where ManyT : IEntity
     {
-        var value = ((IEnumerable<object>)manyValues[0]).Cast<ManyT>();
-        if (mergeOption == MergeOption.NoTracking)
-        {
-            object oneValue = ((IEnumerable<object>)oneValues).Cast<OneT>();
-            var ones = ((IEnumerable<object>)oneValue).Cast<OneT>();
-            foreach (var one in ones)
-                foreach (var manyEntity in value.Where(m => fkTest(one, m)))
-                    getTrackableCollection(one).Attach(manyEntity);
-        }
-        return value;
+		var value = ((IEnumerable<object>)manyValues[0]).Cast<ManyT>();
+		if (mergeOption == MergeOption.NoTracking)
+		{
+			object oneValue = ((IEnumerable<object>)oneValues).Cast<OneT>();
+			var ones = ((IEnumerable<object>)oneValue).Cast<OneT>().ToArray();
+			var manyList = value.ToArray();
+			foreach (var one in ones)
+			{
+				for (int i = 0; i < manyList.Length; i++)
+				{
+					if (fkTest(one, manyList[i]))
+					{
+						getTrackableCollection(one).Attach(manyList[i]);
+					}
+				}
+			}
+		}
+
+		return value;
     }
         
     public static IAsyncQueryableValue<IEnumerable<OneT>> IncludeManyOneToOneMany<OneT, ManyT>(IAsyncQueryableValue<IEnumerable<OneT>> source, Expression<Func<OneT, IEnumerable<ManyT>>> exp, Expression<Func<IEnumerable<ManyT>, ManyT>> queryTransform, Func<OneT, ManyT, bool> fkTest, Func<OneT, IEntityCollection<ManyT>> getTrackableCollection, bool manyToMany = false)
@@ -2170,15 +2194,24 @@ public static class AsyncQueryableExtensions
         where OneT : IEntity
         where ManyT : IEntity
     {
-        var many = ((IEnumerable<object>)manyValues).Cast<ManyT>();
-        if (mergeOption == MergeOption.NoTracking)
-        {
-            var ones = ((IEnumerable<object>)oneValues).Cast<OneT>();
-            foreach (var one in ones)
-                foreach (var manyEntity in many.Where(m => fkTest(one, m)))
-                    getTrackableCollection(one).Attach(manyEntity);
-        }
-        return many;
+		var many = ((IEnumerable<object>)manyValues).Cast<ManyT>();
+		if (mergeOption == MergeOption.NoTracking)
+		{
+			var ones = ((IEnumerable<object>)oneValues).Cast<OneT>().ToArray();
+			var manyList = many.ToArray();
+			foreach (var one in ones)
+			{
+				for (int i = 0; i < manyList.Length; i++)
+				{
+					if (fkTest(one, manyList[i]))
+					{
+						getTrackableCollection(one).Attach(manyList[0]);
+					}
+				}
+			}
+		}
+
+		return many;
     }
         
     public static IAsyncQueryable<ManyT> IncludeManyToOne<ManyT, OneT>(IAsyncQueryable<ManyT> source, IAsyncQueryable<OneT> onesEntitySet, Expression<Func<ManyT, OneT>> exp, Expression<Func<ManyT, OneT, bool>> anyExp, Expression<Func<OneT, OneT>> queryTransform, Func<ManyT, OneT, bool> fkTest, Action<ManyT, OneT> setOne)
@@ -2246,22 +2279,25 @@ public static class AsyncQueryableExtensions
         where OneT : IEntity
         where ManyT : IEntity
     {
-        var ones = ((IEnumerable<object>)oneValues[0]).Cast<OneT>();
-        if (mergeOption == MergeOption.NoTracking)
-        {
-            var many = ((IEnumerable<object>)manyValues).Cast<ManyT>();
-            foreach (var manyElt in many)
-            {
-                var one = ones.Where(e => e != null).FirstOrDefault(e => fkTest(manyElt, e));
-                if (one != null)
-                {
-                    manyElt.IsInitializingRelationships = true;
-                    setOne(manyElt, one);
-                    manyElt.IsInitializingRelationships = false;
-                }
-            }
-        }
-        return ones;
+		var ones = ((IEnumerable<object>)oneValues[0]).Cast<OneT>();
+		if (mergeOption == MergeOption.NoTracking)
+		{
+			var onesArray = ones.Where(e => e != null).ToArray();
+			var many = ((IEnumerable<object>)manyValues).Cast<ManyT>().ToArray();
+			for (int i = 0; i < many.Length; i++)
+			{
+				var one = onesArray.FirstOrDefault(e => fkTest(many[i], e));
+				if (one != null)
+				{
+					many[i].IsInitializingRelationships = true;
+					setOne(many[i], one);
+					many[i].IsInitializingRelationships = false;
+				}
+			}
+
+		}
+
+		return ones;
     }
         
     private static object IncludeOneManyToOne<ManyT, OneT>(object manyValues, object[] oneValues, MergeOption mergeOption, Action<ManyT, OneT> setOne)
@@ -2702,22 +2738,27 @@ public static class AsyncQueryableExtensions
         where FromT : IEntity
         where ToT : IEntity
     {
-        var tos = ((IEnumerable<object>)toValues).Cast<ToT>();
-        var froms = ((IEnumerable<object>)fromValues).Cast<FromT>();
-        if (mergeOption == MergeOption.NoTracking)
-        {
-            foreach (var from in froms)
-                foreach (var to in tos.Where(m => fkTest(from, m)))
-                {
-                    if (to != null)
-                    {
-                        to.IsInitializingRelationships = true;
-                        setTo(from, to);
-                        to.IsInitializingRelationships = false;
-                    }
-                }
-        }
-        return tos;
+		var tos = ((IEnumerable<object>)toValues).Cast<ToT>();
+		var froms = ((IEnumerable<object>)fromValues).Cast<FromT>();
+		if (mergeOption == MergeOption.NoTracking)
+		{
+			var fromsArray = froms.ToArray();
+			var tosArray = ((IEnumerable<object>)toValues[0]).Cast<ToT>().ToArray();
+			foreach (var from in fromsArray)
+			{
+				for (int i = 0; i < tosArray.Length; i++)
+				{
+					if (tosArray[i] != null && fkTest(from, tosArray[i]))
+					{
+						tosArray[i].IsInitializingRelationships = true;
+						setTo(from, tosArray[i]);
+						tosArray[i].IsInitializingRelationships = false;
+					}
+				}
+			}
+		}
+
+		return tos;
     }
         
     private static IAsyncQueryable<T> RemoveSelectFromSource<T>(this IAsyncQueryable<T> source)


### PR DESCRIPTION
I optimize the methods Include for MergeOption.NoTracking
Example : Query Ctx.Bes_Asso_Fou.AsAsync().Where(f => f == ‘CERP’).IncludeBienEtService()
IncludeManyToOne : 9565 Bes_Asso_Fou – 9565 BienEtService
Before 4107 ms, After 2712 ms
