### PR TITLE
Check if entity already added

### DIFF
--- a/WAQS.Client/ttincludes/WAQS.Client.ClientContext.ttinclude
+++ b/WAQS.Client/ttincludes/WAQS.Client.ClientContext.ttinclude
@@ -739,13 +739,16 @@ public partial class <#=contextName#> : <#=contextBaseName#>, I<#=contextName#>,
 <#+
         }
 #>
+        if (!ClientEntitySetExtensions.AddEntityInDico(<#=entityTypeNamePlurial#>, entity)) 
+		{
+			return;
+		}
 
-        ClientEntitySetExtensions.AddEntityInDico(<#=entityTypeNamePlurial#>, entity);
         <#=entitySetEntityTypeName#> entityTmp;
         if (<#=entitySetEntityTypeNamePlurial#>DataTransferDico.TryGetValue(entity.DataTransferEntityKey, out entityTmp))
         {
             if (entityTmp == entity)
-                new InvalidOperationException();
+                throw new InvalidOperationException();
         }
         else
             <#=entitySetEntityTypeNamePlurial#>DataTransferDico.Add(entity.DataTransferEntityKey, entity);		


### PR DESCRIPTION
As part of entity inheritance, when an entity is attached to the context , the method EntityAddedOrAttached of the child is called twice, once by the parent who calls EntityAddedOrAttached of the child then the EntityAddedOrAttached of the child.
In addition, there was a new InvalidOperationException() without throw .
Best regards
Benjamin