### PR TITLE
Fix CascadeDelete

### DIFF
--- a/WAQS.Client/ttincludes/WAQS.Client.ClientContext.ttinclude
+++ b/WAQS.Client/ttincludes/WAQS.Client.ClientContext.ttinclude
@@ -1544,6 +1544,7 @@ if (useEntityremovings)
         EntityAttachWithoutChangingStateSubEntitiesBody((<#=clientEntitiesNamespace#>.<#=code.Escape(entityType.BaseType)#>)entity, (<#=clientEntitiesNamespace#>.<#=code.Escape(entityType.BaseType)#>)entityInCache);
 <#+
     }
+	bool isFirstTime = true;
     foreach (var navigationProperty in entityType.NavigationProperties.Where(np => (isEntitySet || np.DeclaringType == entityType) && IsPublic(np)))
     {
         bool cascadeDeleteFrom = navigationProperty.FromEndMember.DeleteBehavior == OperationAction.Cascade;
@@ -1642,9 +1643,13 @@ if (useEntityremovings)
             if (!hasCascadeDelete && cascadeDeleteTo)
             {
                 hasCascadeDelete = true;
+				if (isFirstTime) 
+				{
+					isFirstTime = false;
 #>
         bool isDeleted = false;
 <#+
+				}
             }
 #>
         if (entity.<#=npName#> != null)


### PR DESCRIPTION
The expression "bool isDeleted = false;"  appears twice in the method EntityAttachWithoutChangingStateSubEntitiesBody
Example :
private void EntityAttachWithoutChangingStateSubEntitiesBody(LeoV200.ClientContexts.Stocks.ReponseRequeteInfoProduit entity, LeoV200.ClientContexts.Stocks.ReponseRequeteInfoProduit entityInCache)
        {
            if (entity == entityInCache)
                return;
            bool isDeleted = false;
            if (entity.BienEtService != null)
            {
                LeoV200.ClientContexts.Stocks.BienEtService parentEntityInCache;
                if (BienEtServicesInternal.Contains(entity.BienEtService))
                    parentEntityInCache = entity.BienEtService;
                else
                    parentEntityInCache = AttachWithoutChangingState(entity.BienEtService, entity.ChangeTracker.State == ObjectState.Unchanged ? ObjectState.Unchanged : ObjectState.Added);
                if (entityInCache != null && ! isDeleted)
                    entityInCache.BienEtService = parentEntityInCache;
            }
            else if (! (entityInCache == null))
            {
                LeoV200.ClientContexts.Stocks.BiensEtService parentEntityInCache;
                if (BiensEtServicesDico.TryGetValue(new BiensEtServiceKeys { Id = entityInCache.IdBienEtService }, out parentEntityInCache))
                {
                    if ((parentEntityInCache.ChangeTracker.State & ObjectState.Deleted) == ObjectState.Deleted)
                    {
                        ReponseRequeteInfoProduitsInternal.RemoveCascade(entityInCache);
                        isDeleted = true;
                    }
                    else
                        entityInCache.BienEtService = (LeoV200.ClientContexts.Stocks.BienEtService)parentEntityInCache;
                }
            }
            if (entity.DisponibiliteFournisseur != null)
            {
                LeoV200.ClientContexts.Stocks.DisponibiliteFournisseur parentEntityInCache;
                if (DisponibiliteFournisseursInternal.Contains(entity.DisponibiliteFournisseur))
                    parentEntityInCache = entity.DisponibiliteFournisseur;
                else
                    parentEntityInCache = AttachWithoutChangingState(entity.DisponibiliteFournisseur, entity.ChangeTracker.State == ObjectState.Unchanged ? ObjectState.Unchanged : ObjectState.Added);
                if (entityInCache != null)
                    entityInCache.DisponibiliteFournisseur = parentEntityInCache;
            }
            else if (! (entityInCache == null))
            {
                LeoV200.ClientContexts.Stocks.DisponibiliteFournisseur parentEntityInCache;
                if (DisponibiliteFournisseursDico.TryGetValue(new DisponibiliteFournisseurKeys { Id = entityInCache.IdDisponibiliteFournisseur }, out parentEntityInCache))
                {
                    entityInCache.DisponibiliteFournisseur = parentEntityInCache;
                }
            }
            bool isDeleted = false;
            if (entity.Fournisseur != null)
            {
                LeoV200.ClientContexts.Stocks.Fournisseur parentEntityInCache;
                if (FournisseursInternal.Contains(entity.Fournisseur))
                    parentEntityInCache = entity.Fournisseur;
                else
                    parentEntityInCache = AttachWithoutChangingState(entity.Fournisseur, entity.ChangeTracker.State == ObjectState.Unchanged ? ObjectState.Unchanged : ObjectState.Added);
                if (entityInCache != null && ! isDeleted)
                    entityInCache.Fournisseur = parentEntityInCache;
            }
            else if (! (entityInCache == null))
            {
                LeoV200.ClientContexts.Stocks.Personne parentEntityInCache;
                if (PersonnesDico.TryGetValue(new PersonneKeys { Id = entityInCache.IdFournisseur }, out parentEntityInCache))
                {
                    if ((parentEntityInCache.ChangeTracker.State & ObjectState.Deleted) == ObjectState.Deleted)
                    {
                        ReponseRequeteInfoProduitsInternal.RemoveCascade(entityInCache);
                        isDeleted = true;
                    }
                    else
                        entityInCache.Fournisseur = (LeoV200.ClientContexts.Stocks.Fournisseur)parentEntityInCache;
                }
            }
        }
